### PR TITLE
Add ability to specify a list of metric names to filter

### DIFF
--- a/aggregation-specifications.yaml
+++ b/aggregation-specifications.yaml
@@ -31,3 +31,10 @@ aggregationSpecifications:
       function: sum
       groupedDimensions:
         - service
+
+  - name: Multi-Name Aggregation
+    aggregatedMetricName: multiNameAgg
+    filteredMetricNameList:
+    - metric1
+    - metric2
+    function: count

--- a/models/aggregation_specification.go
+++ b/models/aggregation_specification.go
@@ -15,16 +15,17 @@
 package models
 
 type AggregationSpecification struct {
-	Name                 string
-	Function	     string
-	FilteredMetricName   string
-	FilteredDimensions   map[string]string
-	GroupedDimensions    []string
-	AggregatedMetricName string
+	Name                   string
+	Function               string
+	FilteredMetricName     string
+	FilteredMetricNameList []string
+	FilteredDimensions     map[string]string
+	GroupedDimensions      []string
+	AggregatedMetricName   string
 	Rollup
 }
 
 type Rollup struct {
-	Function string
+	Function          string
 	GroupedDimensions []string
 }


### PR DESCRIPTION
New option is not compatible with single name option
and only one or the other can be specified.