### PR TITLE
json.Marshal(metricEnvelope) return valuetype already []byte.not nece…

### DIFF
--- a/server.go
+++ b/server.go
@@ -228,7 +228,7 @@ func publishAggregations(outbound chan *kafka.Message, topic *string, c *kafka.C
 				metric.CreationTime = time.Now().Unix() * 1000
 				value, _ := json.Marshal(metric)
 
-				outbound <- &kafka.Message{TopicPartition: kafka.TopicPartition{Topic: topic, Partition: kafka.PartitionAny}, Value: []byte(value)}
+				outbound <- &kafka.Message{TopicPartition: kafka.TopicPartition{Topic: topic, Partition: kafka.PartitionAny}, Value: value}
 				outCounter.Inc()
 			}
 		}

--- a/tools/publisher.go
+++ b/tools/publisher.go
@@ -81,7 +81,7 @@ func main() {
 
 				value, _ := json.Marshal(metricEnvelope)
 
-				p.ProduceChannel() <- &kafka.Message{TopicPartition: kafka.TopicPartition{Topic: &topic, Partition: kafka.PartitionAny}, Value: []byte(value)}
+				p.ProduceChannel() <- &kafka.Message{TopicPartition: kafka.TopicPartition{Topic: &topic, Partition: kafka.PartitionAny}, Value: value}
 			}
 		}
 


### PR DESCRIPTION

json.Marshal(metricEnvelope) return valuetype already []byte.not necessary to be transformed to []byte.